### PR TITLE
fix Outcomes User Progress does not load when using Safari

### DIFF
--- a/src/big-trend/big-trend.js
+++ b/src/big-trend/big-trend.js
@@ -596,15 +596,15 @@ export class BigTrend extends mixinBehaviors(
 		const scrollMax = this.scrollContainer.scrollLeftMax
             || (this.scrollContainer.scrollWidth - this.scrollContainer.offsetWidth);
 
-		if (this.scrollContainer.scrollLeft === 0) {
+		if (this.scrollContainer.scrollLeft === 0 && !this.scrollButtonLeft.classList.contains('hidden')) {
 			this.scrollButtonLeft.classList.add('hidden');
-		} else {
+		} else if (this.scrollContainer.scrollLeft !== 0 && this.scrollButtonLeft.classList.contains('hidden')) {
 			this.scrollButtonLeft.classList.remove('hidden');
 		}
 
-		if (this.scrollContainer.scrollLeft === scrollMax) {
+		if (this.scrollContainer.scrollLeft === scrollMax && !this.scrollButtonRight.classList.contains('hidden')) {
 			this.scrollButtonRight.classList.add('hidden');
-		} else {
+		} else if (this.scrollContainer.scrollLeft !== scrollMax && this.scrollButtonRight.classList.contains('hidden')) {
 			this.scrollButtonRight.classList.remove('hidden');
 		}
 	}


### PR DESCRIPTION
somehow the `_onDataScrolled()` function will loop forever in safari and cause the page to not load.....

the `scroll` event seems bugged on safari for the `scrollContainer`(not too sure what is wrong)

my change will at least stop the function from the endless looping....