### PR TITLE
Add hierarchy view to outcome list

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,19 +12,20 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "dependencies": {
+    "@brightspace-ui/core": "^1.30.0",
     "@polymer/polymer": "^3.2.0",
     "d2l-activity-alignments": "Brightspace/d2l-activity-alignments.git#semver:^1",
     "d2l-button": "BrightspaceUI/button#semver:^5",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-hypermedia-constants": "Brightspace/d2l-hypermedia-constants#semver:^6",
+    "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
+    "d2l-more-less": "BrightspaceUI/more-less#semver:^5",
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1",
     "d2l-resize-aware": "BrightspaceUI/resize-aware#semver:^1",
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
-    "d2l-more-less": "BrightspaceUI/more-less#semver:^5",
-    "siren-entity": "BrightspaceHypermediaComponents/siren-entity#semver:^1",
-    "s-html": "Brightspace/s-html#semver:^2"
+    "s-html": "Brightspace/s-html#semver:^2",
+    "siren-entity": "BrightspaceHypermediaComponents/siren-entity#semver:^1"
   },
   "devDependencies": {
     "@webcomponents/webcomponentsjs": "^2.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-user-progress",
-  "version": "1.3.10",
+  "version": "1.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/demonstration-activity-provider.js
+++ b/src/demonstration-activity-provider.js
@@ -19,7 +19,7 @@ D2L.PolymerBehaviors.OutcomesUserProgress.DemonstrationActivityProviderBehaviorI
 			return [];
 		}
 
-		const activities = entity.getSubEntitiesByClass('user-progress-outcome-activity');
+		const activities = entity.getSubEntitiesByClass(hmConsts.Classes.userProgress.outcomes.activity);
 
 		const uauHrefs = [];
 		activities.forEach(activity => {

--- a/src/outcomes-list/oucomes-tree-node.js
+++ b/src/outcomes-list/oucomes-tree-node.js
@@ -195,7 +195,7 @@ export class OutcomesTreeNode extends mixinBehaviors(
 	}
 
 	_getActivitiesHref(entity) {
-		if (entity && entity.hasClass('user-progress-outcome-node')) {
+		if (entity && entity.hasClass(hmConsts.Classes.userProgress.outcomes.outcomeTreeNode)) {
 			const activitiesLink = entity.getLinkByRel(hmConsts.Rels.UserProgress.outcomeActivities);
 			if (activitiesLink) {
 				return activitiesLink.href;
@@ -205,8 +205,8 @@ export class OutcomesTreeNode extends mixinBehaviors(
 	}
 
 	_getChildren(entity) {
-		if (entity && entity.hasClass('user-progress-outcome-node')) {
-			const subEntities = entity.getSubEntitiesByClass('user-progress-outcome-node');
+		if (entity && entity.hasClass(hmConsts.Classes.userProgress.outcomes.outcomeTreeNode)) {
+			const subEntities = entity.getSubEntitiesByClass(hmConsts.Classes.userProgress.outcomes.outcomeTreeNode);
 			if (subEntities && subEntities.length) {
 				return subEntities;
 			}
@@ -230,7 +230,7 @@ export class OutcomesTreeNode extends mixinBehaviors(
 	}
 
 	_getOutcomeHref(entity) {
-		if (entity && entity.hasClass('user-progress-outcome-node')) {
+		if (entity && entity.hasClass(hmConsts.Classes.userProgress.outcomes.outcomeTreeNode)) {
 			return entity.getLinkByRel(hmConsts.Rels.Outcomes.outcome).href;
 		}
 		return null;

--- a/src/outcomes-list/oucomes-tree-node.js
+++ b/src/outcomes-list/oucomes-tree-node.js
@@ -25,19 +25,24 @@ export class OutcomesTreeNode extends mixinBehaviors(
 		const template = html`
 			<style include="d2l-typography">
 				#container {
-					border-top: 1px solid var(--d2l-color-mica);
+					align-items: center;
+					display: flex;
 				}
 
 				#content {
+					align-items: center;
+					border-bottom: 1px solid var(--d2l-color-mica);
 					display: flex;
+					flex-grow: 1;
 					padding: 18px 0px;
 				}
 
-				#content:not(.leaf-node) .main-text {
-					font-weight: bold;
+				#content.leaf-node {
+					margin-left: 48px;
 				}
 
-				#content:not(.leaf-node) .sub-text {
+				#content:not(.leaf-node) .sub-text,
+				#content .sub-text:empty {
 					display: none;
 				}
 
@@ -52,7 +57,7 @@ export class OutcomesTreeNode extends mixinBehaviors(
 				}
 
 				.button-toggle-collapse {
-					margin-right: 8px;
+					margin-right: 6px;
 				}
 
 				#primary {
@@ -64,6 +69,11 @@ export class OutcomesTreeNode extends mixinBehaviors(
 
 				#primary .main-text {
 					@apply --d2l-body-text;
+				}
+
+				#primary .main-text h2,
+				#primary .main-text h3 {
+					margin: 0px;
 				}
 
 				#primary .sub-text {
@@ -81,7 +91,7 @@ export class OutcomesTreeNode extends mixinBehaviors(
 				}
 
 				#children {
-					margin-left: 18px;
+					margin-left: 36px;
 				}
 
 				@keyframes skeleton-pulse {
@@ -115,17 +125,29 @@ export class OutcomesTreeNode extends mixinBehaviors(
 			</style>
 			<siren-entity href="[[_outcomeHref]]" token="[[token]]" entity="{{_outcomeEntity}}"></siren-entity>
 			<div id="container" role="listitem" aria-busy$="[[!_outcomeEntity]]">
+				<template is="dom-if" if="[[!_isEmpty(_children)]]">
+					<d2l-button-icon
+						class="button-toggle-collapse"
+						icon="[[_getCollapseIcon(_collapsed)]]"
+						on-click="_onItemClicked"
+					></d2l-button-icon>
+				</template>
 				<div id="content" on-click="_onItemClicked" class$="[[_getContentClass(_children)]]">
-					<template is="dom-if" if="[[!_isEmpty(_children)]]">
-						<d2l-button-icon
-							class="button-toggle-collapse"
-							icon="[[_getCollapseIcon(_collapsed)]]"
-							on-click="_onItemClicked"
-						></d2l-button-icon>
-					</template>
 					<div id="primary">
 						<template is="dom-if" if="[[_outcomeEntity]]">
-							<div class="main-text">[[getOutcomeDescriptionPlainText(_outcomeEntity)]]</div>
+							<div class="main-text">
+								<template is="dom-if" if="[[!_isEmpty(_children)]]">
+									<template is="dom-if" if="[[!hasParent]]">
+										<h2>[[getOutcomeDescriptionPlainText(_outcomeEntity)]]</h2>
+									</template>
+									<template is="dom-if" if="[[hasParent]]">
+										<h3>[[getOutcomeDescriptionPlainText(_outcomeEntity)]]</h3>
+									</template>
+								</template>
+								<template is="dom-if" if="[[_isEmpty(_children)]]">
+									[[getOutcomeDescriptionPlainText(_outcomeEntity)]]
+								</template>
+							</div>
 							<div class="sub-text">[[getOutcomeIdentifier(_outcomeEntity)]]</div>
 						</template>
 						<template is="dom-if" if="[[!_outcomeEntity]]">
@@ -146,14 +168,14 @@ export class OutcomesTreeNode extends mixinBehaviors(
 						></d2l-mini-trend>
 					</div>
 				</div>
-				<template is="dom-if" if="[[!_isEmpty(_children)]]">
-					<div id="children" hidden$="[[_collapsed]]">
-						<template is="dom-repeat" items="[[_children]]">
-							<d2l-outcomes-tree-node href="[[_getSelfHref(item)]]" token="[[token]]"></d2l-outcomes-tree-node>
-						</template>
-					</div>
-				</template>
 			</div>
+			<template is="dom-if" if="[[!_isEmpty(_children)]]">
+				<div id="children" hidden$="[[_collapsed]]">
+					<template is="dom-repeat" items="[[_children]]">
+						<d2l-outcomes-tree-node href="[[_getSelfHref(item)]]" token="[[token]]" has-parent=""></d2l-outcomes-tree-node>
+					</template>
+				</div>
+			</template>
 		`;
 		template.setAttribute('strip-whitespace', true);
 		return template;
@@ -170,6 +192,10 @@ export class OutcomesTreeNode extends mixinBehaviors(
 				computed: '_getChildren(entity)'
 			},
 			_collapsed: {
+				type: Boolean,
+				value: false
+			},
+			hasParent: {
 				type: Boolean,
 				value: false
 			},

--- a/src/outcomes-list/oucomes-tree-node.js
+++ b/src/outcomes-list/oucomes-tree-node.js
@@ -1,0 +1,268 @@
+import '@polymer/polymer/polymer-legacy.js';
+import { PolymerElement, html } from '@polymer/polymer';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import 'd2l-polymer-siren-behaviors/store/entity-behavior';
+import 'siren-entity/siren-entity.js';
+import '@brightspace-ui/core/components/button/button-icon';
+import '@brightspace-ui/core/components/colors/colors';
+import 'd2l-typography/d2l-typography.js';
+import 'd2l-typography/d2l-typography-shared-styles.js';
+import OutcomeParserBehaviour from 'd2l-activity-alignments/d2l-outcome-parser-behavior.js';
+import * as hmConsts from 'd2l-hypermedia-constants';
+import { oupConsts } from '../consts';
+import '../mini-trend/mini-trend';
+
+export class OutcomesTreeNode extends mixinBehaviors(
+	[
+		D2L.PolymerBehaviors.Siren.EntityBehavior,
+		OutcomeParserBehaviour
+	],
+	PolymerElement
+) {
+	static get is() { return 'd2l-outcomes-tree-node'; }
+
+	static get template() {
+		const template = html`
+			<style include="d2l-typography">
+				#container {
+					border-top: 1px solid var(--d2l-color-mica);
+				}
+
+				#content {
+					display: flex;
+					padding: 18px 0px;
+				}
+
+				#content:not(.leaf-node) .main-text {
+					font-weight: bold;
+				}
+
+				#content:not(.leaf-node) .sub-text {
+					display: none;
+				}
+
+				:not([aria-busy]) #content:hover {
+					cursor: pointer;
+				}
+
+				:not([aria-busy]) #content.leaf-node:hover .main-text {
+					color: blue;
+					color: var(--d2l-color-celestine-minus-1);
+					text-decoration: underline;
+				}
+
+				.button-toggle-collapse {
+					margin-right: 8px;
+				}
+
+				#primary {
+					display: flex;
+					flex-direction: column;
+					flex-grow: 1;
+					justify-content: center;
+				}
+
+				#primary .main-text {
+					@apply --d2l-body-text;
+				}
+
+				#primary .sub-text {
+					@apply --d2l-body-small-text;
+					margin-top: 6px;
+					width: 100%;
+				}
+
+				#secondary {
+					display: flex;
+					flex-shrink: 0;
+					justify-content: flex-end;
+					margin-left: 24px;
+					min-width: 84px;
+				}
+
+				#children {
+					margin-left: 18px;
+				}
+
+				@keyframes skeleton-pulse {
+					from { background-color: var(--d2l-color-sylvite); }
+					to { background-color: var(--d2l-color-regolith); }
+				}
+
+				.skeleton {
+					animation-direction: alternate;
+					animation-duration: 1.8s;
+					animation-iteration-count: infinite;
+					animation-name: skeleton-pulse;
+					background-color: var(--d2l-color-sylvite);
+					border-radius: 4px;
+					display: inline-block;
+				}
+
+				.main-text .skeleton {
+					height: 19px;
+					width: 100%;
+				}
+
+				.sub-text .skeleton {
+					height: 14px;
+					width: 20%;
+				}
+
+				[hidden] {
+					display: none !important;
+				}
+			</style>
+			<siren-entity href="[[_outcomeHref]]" token="[[token]]" entity="{{_outcomeEntity}}"></siren-entity>
+			<div id="container" role="listitem" aria-busy$="[[!_outcomeEntity]]">
+				<div id="content" on-click="_onItemClicked" class$="[[_getContentClass(_children)]]">
+					<template is="dom-if" if="[[!_isEmpty(_children)]]">
+						<d2l-button-icon
+							class="button-toggle-collapse"
+							icon="[[_getCollapseIcon(_collapsed)]]"
+							on-click="_onItemClicked"
+						></d2l-button-icon>
+					</template>
+					<div id="primary">
+						<template is="dom-if" if="[[_outcomeEntity]]">
+							<div class="main-text">[[getOutcomeDescriptionPlainText(_outcomeEntity)]]</div>
+							<div class="sub-text">[[getOutcomeIdentifier(_outcomeEntity)]]</div>
+						</template>
+						<template is="dom-if" if="[[!_outcomeEntity]]">
+							<div class="main-text">
+								<div class="skeleton"></div>
+								<div class="skeleton"></div>
+							</div>
+							<div class="sub-text">
+								<div class="skeleton"></div>
+							</div>
+						</template>
+					</div>
+					<div id="secondary" hidden$="[[!_activitiesHref]]">
+						<d2l-mini-trend
+							hidden$="[[!_outcomeEntity]]"
+							href="[[_activitiesHref]]"
+							token="[[token]]"
+						></d2l-mini-trend>
+					</div>
+				</div>
+				<template is="dom-if" if="[[!_isEmpty(_children)]]">
+					<div id="children" hidden$="[[_collapsed]]">
+						<template is="dom-repeat" items="[[_children]]">
+							<d2l-outcomes-tree-node href="[[_getSelfHref(item)]]" token="[[token]]"></d2l-outcomes-tree-node>
+						</template>
+					</div>
+				</template>
+			</div>
+		`;
+		template.setAttribute('strip-whitespace', true);
+		return template;
+	}
+
+	static get properties() {
+		return {
+			_activitiesHref: {
+				type: String,
+				computed: '_getActivitiesHref(entity)'
+			},
+			_children: {
+				type: Array,
+				computed: '_getChildren(entity)'
+			},
+			_collapsed: {
+				type: Boolean,
+				value: false
+			},
+			_outcomeEntity: {
+				type: Object,
+				value: null
+			},
+			_outcomeHref: {
+				type: String,
+				computed: '_getOutcomeHref(entity)'
+			},
+			_selfHref: {
+				type: String,
+				computed: '_getSelfHref(entity)'
+			}
+		};
+	}
+
+	static get observers() {
+		return [
+			'_onEntityChanged(entity)'
+		];
+	}
+
+	_getActivitiesHref(entity) {
+		if (entity && entity.hasClass('user-progress-outcome-node')) {
+			const activitiesLink = entity.getLinkByRel(hmConsts.Rels.UserProgress.outcomeActivities);
+			if (activitiesLink) {
+				return activitiesLink.href;
+			}
+		}
+		return null;
+	}
+
+	_getChildren(entity) {
+		if (entity && entity.hasClass('user-progress-outcome-node')) {
+			const subEntities = entity.getSubEntitiesByClass('user-progress-outcome-node');
+			if (subEntities && subEntities.length) {
+				return subEntities;
+			}
+		}
+
+		return [];
+	}
+
+	_getCollapseIcon(collapsed) {
+		return `d2l-tier1:arrow-${collapsed ? 'expand' : 'collapse'}`;
+	}
+
+	_getContentClass(children) {
+		const classes = [];
+
+		if (children && this._isEmpty(children)) {
+			classes.push('leaf-node');
+		}
+
+		return classes.join(';');
+	}
+
+	_getOutcomeHref(entity) {
+		if (entity && entity.hasClass('user-progress-outcome-node')) {
+			return entity.getLinkByRel(hmConsts.Rels.Outcomes.outcome).href;
+		}
+		return null;
+	}
+
+	_getSelfHref(entity) {
+		if (entity) {
+			return entity.getLinkByRel('self').href;
+		}
+		return null;
+	}
+
+	_isEmpty(children) {
+		return !children || children.length === 0;
+	}
+
+	_onItemClicked(e) {
+		if (this._outcomeEntity) {
+			e.stopPropagation();
+			e.preventDefault();
+
+			if (this._isEmpty(this._children)) {
+				this.dispatchEvent(new CustomEvent(oupConsts.events.outcomeListItemClicked, { composed: true, bubbles: true, detail: { href: this._selfHref } }));
+			} else {
+				this._toggleCollapse();
+			}
+		}
+	}
+
+	_toggleCollapse() {
+		this._collapsed = !this._collapsed;
+	}
+}
+
+customElements.define(OutcomesTreeNode.is, OutcomesTreeNode);

--- a/src/outcomes-list/outcomes-list.js
+++ b/src/outcomes-list/outcomes-list.js
@@ -5,6 +5,7 @@ import 'd2l-colors/d2l-colors.js';
 import 'd2l-polymer-siren-behaviors/store/entity-behavior';
 import 'd2l-typography/d2l-typography.js';
 import * as hmConsts from 'd2l-hypermedia-constants';
+import './oucomes-tree-node';
 import './outcomes-list-item';
 import '../localize-behavior';
 
@@ -43,7 +44,12 @@ export class OutcomesList extends mixinBehaviors(
 						[[_getEmptyMessage(instructor, outcomeTerm)]]
 					</div>
 					<template is="dom-repeat" items="[[_outcomes]]">
-						<d2l-outcomes-list-item href="[[_getOutcomeHref(item)]]" token="[[token]]"></d2l-outcomes-list-item>
+						<template is="dom-if" if="[[_isHierarchy]]">
+							<d2l-outcomes-tree-node href="[[_getOutcomeHref(item)]]" token="[[token]]"></d2l-outcomes-tree-node>
+						</template>
+						<template is="dom-if" if="[[_isList]]">
+							<d2l-outcomes-list-item href="[[_getOutcomeHref(item)]]" token="[[token]]"></d2l-outcomes-list-item>
+						</template>
 					</template>
 				</template>
             </div>
@@ -57,6 +63,12 @@ export class OutcomesList extends mixinBehaviors(
 			instructor: {
 				type: Boolean,
 				value: false
+			},
+			_isHierarchy: {
+				computed: '_getIsHierarchy(entity)'
+			},
+			_isList: {
+				computed: '_getIsList(entity)'
 			},
 			outcomeTerm: String,
 			_outcomes: {
@@ -75,6 +87,14 @@ export class OutcomesList extends mixinBehaviors(
 		return this.localize(langTerm, 'outcome', outcomeTerm);
 	}
 
+	_getIsHierarchy(entity) {
+		return entity && entity.hasClass('user-progress-outcome-nodes');
+	}
+
+	_getIsList(entity) {
+		return entity && entity.hasClass(hmConsts.Classes.userProgress.outcomes.outcomes);
+	}
+
 	_getOutcomeHref(outcomeEntity) {
 		return outcomeEntity.getLinkByRel('self').href;
 	}
@@ -86,7 +106,9 @@ export class OutcomesList extends mixinBehaviors(
 	_onEntityChanged(entity) {
 		let outcomes = [];
 
-		if (entity && entity.hasClass(hmConsts.Classes.userProgress.outcomes.outcomes)) {
+		if (this._isHierarchy) {
+			outcomes = entity.getSubEntitiesByClass('user-progress-outcome-node');
+		} else if (this._isList) {
 			outcomes = entity.getSubEntitiesByClass(hmConsts.Classes.userProgress.outcomes.outcome);
 		}
 

--- a/src/outcomes-list/outcomes-list.js
+++ b/src/outcomes-list/outcomes-list.js
@@ -88,7 +88,7 @@ export class OutcomesList extends mixinBehaviors(
 	}
 
 	_getIsHierarchy(entity) {
-		return entity && entity.hasClass('user-progress-outcome-nodes');
+		return entity && entity.hasClass(hmConsts.Classes.userProgress.outcomes.outcomeTree);
 	}
 
 	_getIsList(entity) {
@@ -107,7 +107,7 @@ export class OutcomesList extends mixinBehaviors(
 		let outcomes = [];
 
 		if (this._isHierarchy) {
-			outcomes = entity.getSubEntitiesByClass('user-progress-outcome-node');
+			outcomes = entity.getSubEntitiesByClass(hmConsts.Classes.userProgress.outcomes.outcomeTreeNode);
 		} else if (this._isList) {
 			outcomes = entity.getSubEntitiesByClass(hmConsts.Classes.userProgress.outcomes.outcome);
 		}


### PR DESCRIPTION
Uses new HM APIs for outcomes user progress and displays outcome list in
hierarchy view instead of flat list of leaf nodes. Still backwards
compatible with old list-view API.