### PR TITLE
Bump version to 1.4.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-user-progress",
-  "version": "1.4.15",
+  "version": "1.4.17",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Looks like when the 1.4.16 release was cut it missed the version bump. Double bumping to get us inline with new release version. Will do new GitHub release after this is merged.