### PR TITLE
US129365 - Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-type: development # only allow development for now

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,14 @@ jobs:
         run: npm ci
       - name: Test
         run: |
-          npm i karma-sauce-launcher@2 --no-save
-          npx karma start karma.sauce.conf.js
+          if ${{env.SAUCE_ACCESS_KEY != ''}}; then
+            echo "Running full test suite"
+            npm i karma-sauce-launcher@2 --no-save
+            npm run test:headless -- karma.sauce.conf.js
+          else
+            echo "Running minimal test suite"
+            npm run test:headless
+          fi
         env:
           SAUCE_USERNAME: Desire2Learn
           SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY_DESIRE2LEARN}}

--- a/.licensechecker.json
+++ b/.licensechecker.json
@@ -1,11 +1,5 @@
 {
   "acceptedScopes": [
     "d2l"
-  ],
-  "manualOverrides": {
-    "axe-core@>=3": "D2L-Open-Source-Special-Exemption (MPL-2.0)",
-    "glob-to-regexp@0.3.0": "BSD-2-Clause",
-    "trim@^0.0.1": "MIT",
-    "valid-url@^1.0.9": "MIT"
-  }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4012,7 +4012,7 @@
       }
     },
     "d2l-outcomes-overall-achievement": {
-      "version": "github:Brightspace/d2l-outcomes-overall-achievement#6d6eb9e07658f661d432a59e0785d1ee45de2c92",
+      "version": "github:Brightspace/d2l-outcomes-overall-achievement#dd2a70e47b61ff79444b525a45910e09d835196e",
       "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1.136.4",
@@ -4021,34 +4021,7 @@
         "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",
         "lit-element": "^2",
         "lit-html": "^1",
-        "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be"
-      },
-      "dependencies": {
-        "@brightspace-ui/core": {
-          "version": "1.147.1",
-          "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.147.1.tgz",
-          "integrity": "sha512-+7RSvaWHSU17IvwWbBGRZxE+R3lrhRurmcDV9/a+1c8MUGATz2uOjfdY4nZT6Mup3wwVswyg/NEbrQd473+Avw==",
-          "requires": {
-            "@brightspace-ui/intl": "^3",
-            "@formatjs/intl-pluralrules": "^1",
-            "@open-wc/dedupe-mixin": "^1.2.17",
-            "@webcomponents/shadycss": "^1",
-            "focus-visible": "^5",
-            "intl-messageformat": "^7",
-            "lit-element": "^2",
-            "prismjs": "^1",
-            "resize-observer-polyfill": "^1"
-          }
-        },
-        "siren-sdk": {
-          "version": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be",
-          "from": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be",
-          "requires": {
-            "@brightspace-ui/core": "^1",
-            "@polymer/polymer": "^3.0.0",
-            "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1"
-          }
-        }
+        "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
       }
     },
     "d2l-polymer-siren-behaviors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2524,9 +2524,9 @@
       "dev": true
     },
     "@types/unist": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.5.tgz",
+      "integrity": "sha512-wnra4Vw9dopnuybR6HBywJ/URYpYrKLoepBTEtgfJup8Ahoi2zJECPP2cwiXp7btTvOT2CULv87aQRA4eZSP6g==",
       "dev": true
     },
     "@types/whatwg-url": {
@@ -5429,9 +5429,9 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -5443,23 +5443,22 @@
       },
       "dependencies": {
         "@nodelib/fs.stat": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
           "dev": true
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "ignore": {
@@ -5476,15 +5475,13 @@
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.2.3"
-          },
-          "dependencies": {
-            "picomatch": {
-              "version": "2.2.3",
-              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-              "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
-              "dev": true
-            }
           }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
         }
       }
     },
@@ -5814,12 +5811,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
-    },
-    "indexes-of": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "indexof": {
@@ -7013,6 +7004,12 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7035,6 +7032,12 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "lodash.uniq": {
@@ -8694,14 +8697,12 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-      "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1",
         "util-deprecate": "^1.0.2"
       }
     },
@@ -10084,16 +10085,16 @@
       "dev": true
     },
     "stylelint": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.12.0.tgz",
-      "integrity": "sha512-P8O1xDy41B7O7iXaSlW+UuFbE5+ZWQDb61ndGDxKIt36fMH50DtlQTbwLpFLf8DikceTAb3r6nPrRv30wBlzXw==",
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.13.1.tgz",
+      "integrity": "sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==",
       "dev": true,
       "requires": {
         "@stylelint/postcss-css-in-js": "^0.37.2",
         "@stylelint/postcss-markdown": "^0.36.2",
         "autoprefixer": "^9.8.6",
-        "balanced-match": "^1.0.0",
-        "chalk": "^4.1.0",
+        "balanced-match": "^2.0.0",
+        "chalk": "^4.1.1",
         "cosmiconfig": "^7.0.0",
         "debug": "^4.3.1",
         "execall": "^2.0.0",
@@ -10102,7 +10103,7 @@
         "file-entry-cache": "^6.0.1",
         "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^11.0.2",
+        "globby": "^11.0.3",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
         "ignore": "^5.1.8",
@@ -10110,10 +10111,10 @@
         "imurmurhash": "^0.1.4",
         "known-css-properties": "^0.21.0",
         "lodash": "^4.17.21",
-        "log-symbols": "^4.0.0",
+        "log-symbols": "^4.1.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.4",
         "normalize-selector": "^0.2.0",
         "postcss": "^7.0.35",
         "postcss-html": "^0.36.0",
@@ -10123,7 +10124,7 @@
         "postcss-safe-parser": "^4.0.2",
         "postcss-sass": "^0.4.4",
         "postcss-scss": "^2.1.1",
-        "postcss-selector-parser": "^6.0.4",
+        "postcss-selector-parser": "^6.0.5",
         "postcss-syntax": "^0.36.2",
         "postcss-value-parser": "^4.1.0",
         "resolve-from": "^5.0.0",
@@ -10134,16 +10135,28 @@
         "style-search": "^0.1.0",
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.0.7",
-        "v8-compile-cache": "^2.2.0",
+        "table": "^6.6.0",
+        "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^3.0.3"
       },
       "dependencies": {
         "@nodelib/fs.stat": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
           "dev": true
+        },
+        "ajv": {
+          "version": "8.6.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+          "integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -10154,10 +10167,16 @@
             "color-convert": "^2.0.1"
           }
         },
+        "balanced-match": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+          "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+          "dev": true
+        },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -10180,17 +10199,16 @@
           "dev": true
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "has-flag": {
@@ -10203,6 +10221,12 @@
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
           "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
         "log-symbols": {
@@ -10223,15 +10247,13 @@
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.2.3"
-          },
-          "dependencies": {
-            "picomatch": {
-              "version": "2.2.3",
-              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-              "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
-              "dev": true
-            }
           }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -10246,6 +10268,20 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "table": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+          "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -10699,12 +10735,6 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
-    },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
     },
     "unist-util-find-all-after": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,13 +1100,13 @@
       "integrity": "sha512-HeNxYOyl6fgWipoqXmQNJDIFPYN8VYZeec8vd8FwE/7NkFx4iU0lRYlKA8/+oETRxf3NzStf/CEeiVZDZkT4oA=="
     },
     "@brightspace-ui/stylelint-config": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/stylelint-config/-/stylelint-config-0.1.0.tgz",
-      "integrity": "sha512-ItayLyu526MF76GLWhUKA7OMctMPUHMBvVEqGcMKmeaKPXDybtisujMeyo9x2rzNLy7ffaWpPHpia0oVV0FvKg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/stylelint-config/-/stylelint-config-0.2.0.tgz",
+      "integrity": "sha512-1+a4R9nDbTXNoSm0vcS0rYt2Gx/e7/fnqoLALG4wtZe3oBStKh4kBCl71zGl07k82RcGsdayCsm5pYXEEiil+Q==",
       "dev": true,
       "requires": {
         "stylelint": "^13",
-        "stylelint-config-recommended": "^4",
+        "stylelint-config-recommended": "^5",
         "stylelint-order": "^4"
       }
     },
@@ -3698,31 +3698,58 @@
       "from": "github:Brightspace/d2l-fetch#semver:^2"
     },
     "d2l-license-checker": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d2l-license-checker/-/d2l-license-checker-3.2.0.tgz",
-      "integrity": "sha512-QxMByV6hRZLvDzH4OwMRC0x4m+zsOsWGe6zCz+eX5dBnJ0l5gj8/rDowsRFhlqSJ/W2YU1usken+3afYGCm9nA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/d2l-license-checker/-/d2l-license-checker-4.1.1.tgz",
+      "integrity": "sha512-3OC4wmHuChEwyoAy3+NrXTY49tKYfx83Erxk00fbiqKkpSbNvPfQERVE1qlmRGfTxlRCf+sDlKsTe+oERVyRLg==",
       "dev": true,
       "requires": {
         "license-checker": "^25.0.1",
         "lodash": "^4.17.21",
-        "semver": "^7.3.4",
-        "spdx-license-ids": "^3.0.7",
-        "spdx-satisfies": "^5.0.0",
-        "yargs": "^16.2.0"
+        "semver": "^7.3.5",
+        "spdx-license-ids": "^3.0.9",
+        "spdx-satisfies": "^5.0.1",
+        "yargs": "^17.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+          "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
+          "dev": true
+        }
       }
     },
     "d2l-outcomes-overall-achievement": {
       "version": "github:Brightspace/d2l-outcomes-overall-achievement#6d6eb9e07658f661d432a59e0785d1ee45de2c92",
       "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
       "requires": {
-        "@brightspace-ui/core": "^1.113.0",
+        "@brightspace-ui/core": "^1.136.4",
         "@open-wc/dedupe-mixin": "^1",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
-        "d2l-table": "github:BrightspaceUI/table#semver:^2",
         "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",
         "lit-element": "^2",
         "lit-html": "^1",
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be"
+      },
+      "dependencies": {
+        "siren-sdk": {
+          "version": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be",
+          "from": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be",
+          "requires": {
+            "@brightspace-ui/core": "^1",
+            "@polymer/polymer": "^3.0.0",
+            "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1"
+          }
+        }
       }
     },
     "d2l-polymer-siren-behaviors": {
@@ -3739,34 +3766,6 @@
       "from": "github:BrightspaceUI/resize-aware#semver:^1",
       "requires": {
         "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "d2l-table": {
-      "version": "github:BrightspaceUI/table#216a599a6f87ea07e778537a42d9043f9cb1a462",
-      "from": "github:BrightspaceUI/table#semver:^2",
-      "requires": {
-        "@brightspace-ui/core": "^1.134",
-        "@polymer/polymer": "^3",
-        "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
-        "fastdom": "^1.0.8"
-      },
-      "dependencies": {
-        "@brightspace-ui/core": {
-          "version": "1.146.0",
-          "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.146.0.tgz",
-          "integrity": "sha512-tH7EprVCfg6c0uD+mPvoQ4yH7kXjfbFno7d1bxzkiiKr5B1PDHNfAegO0gP81UUVioYCQcABY06kACEcV4gm2w==",
-          "requires": {
-            "@brightspace-ui/intl": "^3",
-            "@formatjs/intl-pluralrules": "^1",
-            "@open-wc/dedupe-mixin": "^1.2.17",
-            "@webcomponents/shadycss": "^1",
-            "focus-visible": "^5",
-            "intl-messageformat": "^7",
-            "lit-element": "^2",
-            "prismjs": "^1",
-            "resize-observer-polyfill": "^1"
-          }
-        }
       }
     },
     "d2l-telemetry-browser-client": {
@@ -4522,9 +4521,9 @@
       "dev": true
     },
     "eslint-plugin-chai-friendly": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.6.0.tgz",
-      "integrity": "sha512-Uvvv1gkbRGp/qfN15B0kQyQWg+oFA8buDSqrwmW3egNSk/FpqH2MjQqKOuKwmEL6w4QIQrIjDp+gg6kGGmD3oQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.7.1.tgz",
+      "integrity": "sha512-0xhGiSQ+9oWtNc6IZPUR+6ChKbEvLXwT9oZZ5NcGlPzHVKGn1YKwQFj7a9yL3rnRKbWF7b3RkRYEP8kN6dPOwQ==",
       "dev": true
     },
     "eslint-plugin-html": {
@@ -4556,13 +4555,30 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
-      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz",
+      "integrity": "sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^2.1.0",
+        "eslint-utils": "^3.0.0",
         "ramda": "^0.27.1"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-sort-class-members": {
@@ -7473,33 +7489,33 @@
       }
     },
     "mocha": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz",
-      "integrity": "sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.2.tgz",
+      "integrity": "sha512-FpspiWU+UT9Sixx/wKimvnpkeW0mh6ROAKkIaPokj3xZgxeRhcna/k5X57jJghEr8X+Cgu/Vegf8zCX5ugSuTA==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.1",
+        "chokidar": "3.5.2",
         "debug": "4.3.1",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "4.0.0",
-        "log-symbols": "4.0.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.20",
-        "serialize-javascript": "5.0.1",
+        "nanoid": "3.1.23",
+        "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
         "wide-align": "1.1.3",
-        "workerpool": "6.1.0",
+        "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -7512,6 +7528,16 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
           }
         },
         "argparse": {
@@ -7527,9 +7553,9 @@
           "dev": true
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -7545,6 +7571,22 @@
                 "has-flag": "^4.0.0"
               }
             }
+          }
+        },
+        "chokidar": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.2",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.6.0"
           }
         },
         "color-convert": {
@@ -7596,6 +7638,20 @@
           "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
           "dev": true
         },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7609,9 +7665,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
@@ -7627,12 +7683,13 @@
           }
         },
         "log-symbols": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
           "dev": true,
           "requires": {
-            "chalk": "^4.0.0"
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
           }
         },
         "ms": {
@@ -7659,6 +7716,15 @@
             "p-limit": "^3.0.2"
           }
         },
+        "readdirp": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -7666,6 +7732,21 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
           }
         },
         "yargs-parser": {
@@ -7706,9 +7787,9 @@
       }
     },
     "nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "dev": true
     },
     "nanomatch": {
@@ -9163,9 +9244,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -9635,9 +9716,9 @@
       "dev": true
     },
     "spdx-satisfies": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-5.0.0.tgz",
-      "integrity": "sha512-/hGhwh20BeGmkA+P/lm06RvXD94JduwNxtx/oX3B5ClPt1/u/m5MCaDNo1tV3Y9laLkQr/NRde63b9lLMhlNfw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
+      "integrity": "sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==",
       "dev": true,
       "requires": {
         "spdx-compare": "^1.0.0",
@@ -9997,9 +10078,9 @@
       }
     },
     "stylelint-config-recommended": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-4.0.0.tgz",
-      "integrity": "sha512-sgna89Ng+25Hr9kmmaIxpGWt2LStVm1xf1807PdcWasiPDaOTkOHRL61sINw0twky7QMzafCGToGDnHT/kTHtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
+      "integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
       "dev": true
     },
     "stylelint-order": {
@@ -11005,9 +11086,9 @@
       }
     },
     "workerpool": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
       "dev": true
     },
     "wrap-ansi": {
@@ -11090,9 +11171,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
     "yallist": {
@@ -11108,9 +11189,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,9 +1078,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.124.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.124.0.tgz",
-      "integrity": "sha512-0+FbamqvHPnLGtcZHyPNWxemKUKRBnzAnblbAh3gs+aSO6L2sE6gs7b2agAvi9hnvSXHueA7pnOrbqRQ12t64w==",
+      "version": "1.147.1",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.147.1.tgz",
+      "integrity": "sha512-+7RSvaWHSU17IvwWbBGRZxE+R3lrhRurmcDV9/a+1c8MUGATz2uOjfdY4nZT6Mup3wwVswyg/NEbrQd473+Avw==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",
@@ -1089,7 +1089,6 @@
         "focus-visible": "^5",
         "intl-messageformat": "^7",
         "lit-element": "^2",
-        "lodash-es": "^4",
         "prismjs": "^1",
         "resize-observer-polyfill": "^1"
       }
@@ -2456,6 +2455,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
+      "dev": true
+    },
     "@types/path-is-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
@@ -2533,11 +2538,289 @@
         "@types/node": "*"
       }
     },
+    "@types/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-ijZ1vzRawI7QoWnTNL8KpHixd2b2XVb9I9HAqI3triPsh1EC0xH0Eg6w2O3TKbDCgiNNlJqfrof6j4T2I+l9vw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "@web/config-loader": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.1.3.tgz",
+      "integrity": "sha512-XVKH79pk4d3EHRhofete8eAnqto1e8mCRAqPV00KLNFzCWSe8sWmLnqKCqkPNARC6nksMaGrATnA5sPDRllMpQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.3.4"
+      }
+    },
+    "@web/dev-server": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.18.tgz",
+      "integrity": "sha512-mMXI9IgowYmRXlKfvDCAPDvfjtuqpo74GmbDbd1ZF5IIHanvCF4d1xBPxc+w403bnbwj2cqjWc8wed+zp8JSoQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.11",
+        "@rollup/plugin-node-resolve": "^11.0.1",
+        "@types/command-line-args": "^5.0.0",
+        "@web/config-loader": "^0.1.3",
+        "@web/dev-server-core": "^0.3.12",
+        "@web/dev-server-rollup": "^0.3.5",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.1",
+        "debounce": "^1.2.0",
+        "deepmerge": "^4.2.2",
+        "ip": "^1.1.5",
+        "open": "^8.0.2",
+        "portfinder": "^1.0.28"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "open": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
+          "integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
+          "dev": true,
+          "requires": {
+            "define-lazy-prop": "^2.0.0",
+            "is-docker": "^2.1.1",
+            "is-wsl": "^2.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@web/dev-server-core": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.3.13.tgz",
+      "integrity": "sha512-bGJHPeFRWATNfuL9Pp2LfqhnmqhBCc5eOO5AWQa0X+WQAwHiFo6xZNfsvsnJ1gvxXgsE4jKBAGu9lQRisvFRFA==",
+      "dev": true,
+      "requires": {
+        "@types/koa": "^2.11.6",
+        "@types/ws": "^7.4.0",
+        "@web/parse5-utils": "^1.2.0",
+        "chokidar": "^3.4.3",
+        "clone": "^2.1.2",
+        "es-module-lexer": "^0.4.0",
+        "get-stream": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "isbinaryfile": "^4.0.6",
+        "koa": "^2.13.0",
+        "koa-etag": "^4.0.0",
+        "koa-send": "^5.0.1",
+        "koa-static": "^5.0.0",
+        "lru-cache": "^6.0.0",
+        "mime-types": "^2.1.27",
+        "parse5": "^6.0.1",
+        "picomatch": "^2.2.2",
+        "ws": "^7.4.2"
+      },
+      "dependencies": {
+        "es-module-lexer": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
+          "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
+        },
+        "koa-etag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/koa-etag/-/koa-etag-4.0.0.tgz",
+          "integrity": "sha512-1cSdezCkBWlyuB9l6c/IFoe1ANCDdPBxkDkRiaIup40xpUub6U/wwRXoKBZw/O5BifX9OlqAjYnDyzM6+l+TAg==",
+          "dev": true,
+          "requires": {
+            "etag": "^1.8.1"
+          }
+        },
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+          "dev": true
+        }
+      }
+    },
+    "@web/dev-server-rollup": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.5.tgz",
+      "integrity": "sha512-eDLy3Da3qXqfPxOB7qZvR5NscXCZ63NyxoyPR0R/ukPs7ThvkAfwrtnKXckQo4vh5+FMytZXhyDcqPgeGDlGlg==",
+      "dev": true,
+      "requires": {
+        "@web/dev-server-core": "^0.3.3",
+        "chalk": "^4.1.0",
+        "parse5": "^6.0.1",
+        "rollup": "^2.35.1",
+        "whatwg-url": "^8.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
+      }
+    },
+    "@web/parse5-utils": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.2.2.tgz",
+      "integrity": "sha512-B68DoJ5qF8Cu3o7nDA2RQTCf9bslVz2b0WHTk3qir5YCbWfhnPEGhDOedOjbE8xDiHqgzI1zXQsJ2+655aluLA==",
+      "dev": true,
+      "requires": {
+        "@types/parse5": "^5.0.3",
+        "parse5": "^6.0.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+          "dev": true
+        }
+      }
     },
     "@webcomponents/shadycss": {
       "version": "1.10.2",
@@ -3741,6 +4024,22 @@
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be"
       },
       "dependencies": {
+        "@brightspace-ui/core": {
+          "version": "1.147.1",
+          "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.147.1.tgz",
+          "integrity": "sha512-+7RSvaWHSU17IvwWbBGRZxE+R3lrhRurmcDV9/a+1c8MUGATz2uOjfdY4nZT6Mup3wwVswyg/NEbrQd473+Avw==",
+          "requires": {
+            "@brightspace-ui/intl": "^3",
+            "@formatjs/intl-pluralrules": "^1",
+            "@open-wc/dedupe-mixin": "^1.2.17",
+            "@webcomponents/shadycss": "^1",
+            "focus-visible": "^5",
+            "intl-messageformat": "^7",
+            "lit-element": "^2",
+            "prismjs": "^1",
+            "resize-observer-polyfill": "^1"
+          }
+        },
         "siren-sdk": {
           "version": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be",
           "from": "github:BrightspaceHypermediaComponents/siren-sdk#a14b30ee354ed5a7c080316fc883361335e989be",
@@ -3869,6 +4168,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true
     },
     "define-properties": {
@@ -4240,111 +4545,6 @@
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
         "unbox-primitive": "^1.0.0"
-      }
-    },
-    "es-dev-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-2.1.0.tgz",
-      "integrity": "sha512-Vrq/4PyMzWz33QmOdSncvoWLTJVcv2e96z8FLHQwP9zK7DyLeDZCckII8VTW+btUGtM7aErvLH/d/R2pjjjs8w==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.11.1",
-        "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-        "@babel/plugin-proposal-optional-chaining": "^7.11.0",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-template-literals": "^7.8.3",
-        "@babel/preset-env": "^7.9.0",
-        "@koa/cors": "^3.1.0",
-        "@open-wc/building-utils": "^2.18.3",
-        "@rollup/plugin-node-resolve": "^11.0.0",
-        "@rollup/pluginutils": "^3.0.0",
-        "@types/babel__core": "^7.1.3",
-        "@types/browserslist": "^4.8.0",
-        "@types/browserslist-useragent": "^3.0.0",
-        "@types/caniuse-api": "^3.0.0",
-        "@types/command-line-args": "^5.0.0",
-        "@types/command-line-usage": "^5.0.1",
-        "@types/debounce": "^1.2.0",
-        "@types/koa": "^2.0.48",
-        "@types/koa-compress": "^2.0.9",
-        "@types/koa-etag": "^3.0.0",
-        "@types/koa-static": "^4.0.1",
-        "@types/koa__cors": "^3.0.1",
-        "@types/lru-cache": "^5.1.0",
-        "@types/mime-types": "^2.1.0",
-        "@types/minimatch": "^3.0.3",
-        "@types/path-is-inside": "^1.0.0",
-        "@types/whatwg-url": "^6.4.0",
-        "browserslist": "^4.9.1",
-        "browserslist-useragent": "^3.0.2",
-        "builtin-modules": "^3.1.0",
-        "camelcase": "^5.3.1",
-        "caniuse-api": "^3.0.0",
-        "caniuse-lite": "^1.0.30001033",
-        "chokidar": "^3.0.0",
-        "command-line-args": "^5.0.2",
-        "command-line-usage": "^6.1.0",
-        "debounce": "^1.2.0",
-        "deepmerge": "^4.2.2",
-        "es-module-lexer": "^0.3.13",
-        "get-stream": "^5.1.0",
-        "is-stream": "^2.0.0",
-        "isbinaryfile": "^4.0.2",
-        "koa": "^2.7.0",
-        "koa-compress": "^3.0.0",
-        "koa-etag": "^3.0.0",
-        "koa-static": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "mime-types": "^2.1.27",
-        "minimatch": "^3.0.4",
-        "open": "^7.0.3",
-        "parse5": "^5.1.1",
-        "path-is-inside": "^1.0.2",
-        "polyfills-loader": "^1.7.4",
-        "portfinder": "^1.0.21",
-        "rollup": "^2.7.2",
-        "strip-ansi": "^5.2.0",
-        "systemjs": "^6.3.1",
-        "tslib": "^1.11.1",
-        "useragent": "^2.3.0",
-        "whatwg-url": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
       }
     },
     "es-module-lexer": {
@@ -5705,6 +5905,12 @@
         "@formatjs/intl-unified-numberformat": "^3.2.0"
       }
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -6828,11 +7034,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -7195,9 +7396,8 @@
       "dev": true
     },
     "messageformat-validator": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/messageformat-validator/-/messageformat-validator-1.1.1.tgz",
-      "integrity": "sha512-CsbH0YUBBOCUXbfQQG/MIDE4+KfutWhLdvShfmd8INLFNmfbwFBSQj9us8HCL7OjF33P6d0W3xpDUBx1Qi2RZA==",
+      "version": "github:bearfriend/messageformat-validator#ca58f845e4896759f1bbe1e6ea34597ccac059d6",
+      "from": "github:bearfriend/messageformat-validator",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@brightspace-ui/core": "^1.124.0",
+    "@brightspace-ui/core": "^1.147.1",
     "@open-wc/dedupe-mixin": "^1",
     "@polymer/iron-a11y-announcer": "^3",
     "@polymer/iron-collapse": "^3",
@@ -33,10 +33,10 @@
     "@brightspace-ui/stylelint-config": "^0.2",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^4",
+    "@web/dev-server": "^0.1",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-license-checker": "^4",
     "deepmerge": "^4",
-    "es-dev-server": "^2",
     "eslint": "^7",
     "eslint-config-brightspace": "^0.14",
     "eslint-plugin-chai-friendly": "^0.7",
@@ -45,7 +45,7 @@
     "eslint-plugin-mocha": "^9",
     "eslint-plugin-sort-class-members": "^1",
     "lit-analyzer": "^1",
-    "messageformat-validator": "^1",
+    "messageformat-validator": "github:bearfriend/messageformat-validator",
     "mocha": "^9",
     "stylelint": "^13"
   }

--- a/package.json
+++ b/package.json
@@ -30,23 +30,23 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7",
-    "@brightspace-ui/stylelint-config": "^0.1",
+    "@brightspace-ui/stylelint-config": "^0.2",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^4",
     "@webcomponents/webcomponentsjs": "^2",
-    "d2l-license-checker": "^3",
+    "d2l-license-checker": "^4",
     "deepmerge": "^4",
     "es-dev-server": "^2",
     "eslint": "^7",
     "eslint-config-brightspace": "^0.14",
-    "eslint-plugin-chai-friendly": "^0.6",
+    "eslint-plugin-chai-friendly": "^0.7",
     "eslint-plugin-html": "^6",
     "eslint-plugin-lit": "^1",
-    "eslint-plugin-mocha": "^8",
+    "eslint-plugin-mocha": "^9",
     "eslint-plugin-sort-class-members": "^1",
     "lit-analyzer": "^1",
     "messageformat-validator": "^1",
-    "mocha": "^8",
+    "mocha": "^9",
     "stylelint": "^13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "Web components for Outcomes User Progress page",
   "scripts": {
-    "license-check": "d2l-license-checker",
+    "license-check": "d2l-license-checker -p",
     "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
     "lint:lit": "lit-analyzer {src,test}/**/*.js --strict",


### PR DESCRIPTION
Only allow development dependency updates for now. Development dependencies are only used for local development and have no effect on downstream dependants. Also update to latest dependencies and switch to `@web/dev-server`